### PR TITLE
feat: use the official Google API python library

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,21 @@ This tap:
   - Process/send records to target
 
 ## Authentication
-The [**Google Sheets Setup & Authentication**](https://drive.google.com/open?id=1FojlvtLwS0-BzGS37R0jEXtwSHqSiO1Uw-7RKQQO-C4) Google Doc provides instructions show how to configure the Google Cloud API credentials to enable Google Drive and Google Sheets APIs, configure Google Cloud to authorize/verify your domain ownership, generate an API key (client_id, client_secret), authenticate and generate a refresh_token, and prepare your tap config.json with the necessary parameters.
-- Enable Googe Drive APIs and Authorization Scope: https://www.googleapis.com/auth/drive.metadata.readonly
-- Enable Google Sheets API and Authorization Scope: https://www.googleapis.com/auth/spreadsheets.readonly
-- Tap config.json parameters:
-  - client_id: identifies your application
-  - client_secret: authenticates your application
-  - refresh_token: generates an access token to authorize your session
-  - spreadsheet_id: unique identifier for each spreadsheet in Google Drive
-  - start_date: absolute minimum start date to check file modified
-  - user_agent: tap-name and email address; identifies your application in the Remote API server logs
+
+You will need a Google developer project to use this tool. After [creating a project](https://console.developers.google.com/projectcreate) (or selecting an existing one) in your Google developers console the authentication can be configured in two different ways:
+
+- Via an OAuth client which will ask the user to login to its Google user account.
+  
+  Please check the [“Creating application credentials”](https://github.com/googleapis/google-api-python-client/blob/d0110cf4f7aaa93d6f56fc028cd6a1e3d8dd300a/docs/oauth-installed.md#creating-application-credentials) paragraph of the Google Python library to download your Google credentials file.
+
+- Via a Service account (ideal for server-to-server communication)
+  
+  Please check the [“Creating a service account”](https://github.com/googleapis/google-api-python-client/blob/d0110cf4f7aaa93d6f56fc028cd6a1e3d8dd300a/docs/oauth-server.md#creating-a-service-account) paragraph of the Google Python library to download your Google Service Account key file.
+
+- Tap `config.json` parameters:
+  - `credentials_file`: the path to a valid Google credentials file (Either an OAuth client secrets file or a Service Account key file)
+  - `spreadsheet_id`: unique identifier for each spreadsheet in Google Drive
+  - `start_date`: absolute minimum start date to check file modified
 
 ## Quick Start
 
@@ -103,16 +108,13 @@ The [**Google Sheets Setup & Authentication**](https://drive.google.com/open?id=
     - [singer-tools](https://github.com/singer-io/singer-tools)
     - [target-stitch](https://github.com/singer-io/target-stitch)
 
-3. Create your tap's `config.json` file. Include the client_id, client_secret, refresh_token, site_urls (website URL properties in a comma delimited list; do not include the domain-level property in the list), start_date (UTC format), and user_agent (tap name with the api user email address).
+3. Create your tap's `config.json` file. Include the `credentials_file` path to your google secrets file as described in the [Authentication](#authentication) paragraph.
 
     ```json
     {
-        "client_id": "YOUR_CLIENT_ID",
-        "client_secret": "YOUR_CLIENT_SECRET",
-        "refresh_token": "YOUR_REFRESH_TOKEN",
+        "credentials_file": "PATH_TO_YOUR_GOOGLE_CREDENTIALS_FILE",
         "spreadsheet_id": "YOUR_GOOGLE_SPREADSHEET_ID",
-        "start_date": "2019-01-01T00:00:00Z",
-        "user_agent": "tap-google-sheets <api_user_email@example.com>"
+        "start_date": "2019-01-01T00:00:00Z"
     }
     ```
     

--- a/config.json.example
+++ b/config.json.example
@@ -1,8 +1,5 @@
 {
-    "client_id": "YOUR_CLIENT_ID",
-    "client_secret": "YOUR_CLIENT_SECRET",
-    "refresh_token": "YOUR_REFRESH_TOKEN",
+    "credentials_file": "client-secrets.json",
     "spreadsheet_id": "YOUR_GOOGLE_SPREADSHEET_ID",
-    "start_date": "2019-01-01T00:00:00Z",
-    "user_agent": "tap-google-search-console <api_user_email@example.com>"
+    "start_date": "2019-01-01T00:00:00Z"
 }

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,10 @@ setup(name='tap-google-sheets',
       py_modules=['tap_google_sheets'],
       install_requires=[
           'backoff==1.8.0',
-          'requests==2.22.0',
-          'singer-python==5.9.0'
+          'singer-python==5.9.0',
+          'google-api-python-client==1.12.5',
+          'google-auth==1.23.0',
+          'google-auth-oauthlib==0.4.2',
       ],
       extras_require={
           'dev': [

--- a/tap_google_sheets/__init__.py
+++ b/tap_google_sheets/__init__.py
@@ -12,12 +12,9 @@ from tap_google_sheets.sync import sync
 LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
-    'client_id',
-    'client_secret',
-    'refresh_token',
+    'credentials_file',
     'spreadsheet_id',
-    'start_date',
-    'user_agent'
+    'start_date'
 ]
 
 def do_discover(client, spreadsheet_id):
@@ -33,10 +30,7 @@ def main():
 
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-    with GoogleClient(parsed_args.config['client_id'],
-                      parsed_args.config['client_secret'],
-                      parsed_args.config['refresh_token'],
-                      parsed_args.config['user_agent']) as client:
+    with GoogleClient(parsed_args.config['credentials_file']) as client:
 
         state = {}
         if parsed_args.state:

--- a/tap_google_sheets/schema.py
+++ b/tap_google_sheets/schema.py
@@ -224,16 +224,13 @@ def get_sheet_metadata(sheet, spreadsheet_id, client):
 
     stream_name = 'sheet_metadata'
     stream_metadata = STREAMS.get(stream_name)
-    api = stream_metadata.get('api', 'sheets')
     params = stream_metadata.get('params', {})
-    sheet_title_encoded = urllib.parse.quote_plus(sheet_title)
-    sheet_title_escaped = re.escape(sheet_title)
-    querystring = '&'.join(['%s=%s' % (key, value) for (key, value) in \
-        params.items()]).replace('{sheet_title}', sheet_title_encoded)
-    path = '{}?{}'.format(stream_metadata.get('path').replace('{spreadsheet_id}', \
-        spreadsheet_id), querystring)
 
-    sheet_md_results = client.get(path=path, api=api, endpoint=sheet_title_escaped)
+    # GET sheet_metadata
+    sheet_md_results = client.request(endpoint=stream_name,
+                                      spreadsheet_id=spreadsheet_id,
+                                      sheet_title=sheet_title,
+                                      params=params)
     # sheet_metadata: 1st `sheets` node in results
     sheet_metadata = sheet_md_results.get('sheets')[0]
 
@@ -275,15 +272,12 @@ def get_schemas(client, spreadsheet_id):
         field_metadata[stream_name] = mdata
 
         if stream_name == 'spreadsheet_metadata':
-            api = stream_metadata.get('api', 'sheets')
             params = stream_metadata.get('params', {})
-            querystring = '&'.join(['%s=%s' % (key, value) for (key, value) in params.items()])
-            path = '{}?{}'.format(stream_metadata.get('path').replace('{spreadsheet_id}', \
-                spreadsheet_id), querystring)
 
             # GET spreadsheet_metadata, which incl. sheets (basic metadata for each worksheet)
-            spreadsheet_md_results = client.get(path=path, params=querystring, api=api, \
-                endpoint=stream_name)
+            spreadsheet_md_results = client.request(endpoint=stream_name,
+                                                    spreadsheet_id=spreadsheet_id,
+                                                    params=params)
 
             sheets = spreadsheet_md_results.get('sheets')
             if sheets:

--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -2,9 +2,7 @@ from collections import OrderedDict
 
 # streams: API URL endpoints to be called
 # properties:
-#   <root node>: Plural stream name for the endpoint
-#   path: API endpoint relative path, when added to the base URL, creates the full path,
-#       default = stream_name
+#   <root node>: Plural stream name which will condition the endpoint called
 #   key_properties: Primary key fields for identifying an endpoint record.
 #   replication_method: INCREMENTAL or FULL_TABLE
 #   replication_keys: bookmark_field(s), typically a date-time, used for filtering the results
@@ -15,51 +13,51 @@ from collections import OrderedDict
 
 # file_metadata: Queries Google Drive API to get file information and see if file has been modified
 #    Provides audit info about who and when last changed the file.
+#    cf https://developers.google.com/drive/api/v3/reference/files/get
 FILE_METADATA = {
-    "api": "files",
-    "path": "files/{spreadsheet_id}",
     "key_properties": ["id"],
     "replication_method": "INCREMENTAL",
     "replication_keys": ["modifiedTime"],
     "params": {
+        "fileId": "{spreadsheet_id}",
         "fields": "id,name,createdTime,modifiedTime,version,teamDriveId,driveId,lastModifyingUser"
     }
 }
 
 # spreadsheet_metadata: Queries spreadsheet to get basic information on spreadhsheet and sheets
+#    cf https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get
 SPREADSHEET_METADATA = {
-    "api": "sheets",
-    "path": "spreadsheets/{spreadsheet_id}",
     "key_properties": ["spreadsheetId"],
     "replication_method": "FULL_TABLE",
     "params": {
-        "includeGridData": "false"
+        "spreadsheetId": "{spreadsheet_id}"
     }
 }
 
 # sheet_metadata: Get Header Row and 1st data row (Rows 1 & 2) from a Sheet on Spreadsheet.
-# This endpoint includes detailed metadata about each cell in the header and first data row
-#   incl. data type, formatting, etc.
+#    This endpoint includes detailed metadata about each cell in the header and first data row
+#    incl. data type, formatting, etc.
+#    cf https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get
 SHEET_METADATA = {
-    "api": "sheets",
-    "path": "spreadsheets/{spreadsheet_id}",
     "key_properties": ["sheetId"],
     "replication_method": "FULL_TABLE",
     "params": {
+        "spreadsheetId": "{spreadsheet_id}",
         "includeGridData": "true",
         "ranges": "'{sheet_title}'!1:2"
     }
 }
 
 # sheets_loaded: Queries a batch of Rows for each Sheet in the Spreadsheet.
-# Each query uses the `values` endpoint, to get data-only, w/out the formatting/type metadata.
+#    Each query uses the `values` endpoint, to get data-only, w/out the formatting/type metadata.
+#    cf https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get
 SHEETS_LOADED = {
-    "api": "sheets",
-    "path": "spreadsheets/{spreadsheet_id}/values/'{sheet_title}'!{range_rows}",
     "data_key": "values",
     "key_properties": ["spreadsheetId", "sheetId", "loadDate"],
     "replication_method": "FULL_TABLE",
     "params": {
+        "spreadsheetId": "{spreadsheet_id}",
+        "range": "'{sheet_title}'!{range_rows}",
         "dateTimeRenderOption": "SERIAL_NUMBER",
         "valueRenderOption": "UNFORMATTED_VALUE",
         "majorDimension": "ROWS"


### PR DESCRIPTION
These changes will make use of the official `google-api-python-client`
library instead of relying on manual HTTP requests.

Therer are two main advantages of these changes:

- the Tap doesn't need to worry about the Google API interaction
  details as its hidden away by the Google official lib.
- We can use the authentication helpers from the lib to ease the
  credentials management for the user. In that way the current PR
  implements two auth mean: installed OAuth client authentication or
  Service Accounts authentication.

The only downside of this change is that it breaks the current
`config.json` parameters for existing users.

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
